### PR TITLE
Handle docker pull errors

### DIFF
--- a/src/docker.ts
+++ b/src/docker.ts
@@ -31,22 +31,26 @@ export function demux(
 }
 
 export function pull(docker: Dockerode, image: string): Promise<void> {
-  return new Promise(resolve => {
+  return new Promise((resolve, reject) => {
     docker.pull(image, {}, (err, stream) => {
-      docker.modem.followProgress(
-        stream,
-        () => {
-          process.stdout.write('\n');
-          resolve();
-        },
-        function(event: any) {
-          readline.clearLine(process.stdout, 0);
-          readline.cursorTo(process.stdout, 0);
-          process.stdout.write(
-            `${event.status} ${event.id || ''} ${event.progress || ''}`
-          );
-        }
-      );
+      if (stream) {
+        docker.modem.followProgress(
+          stream,
+          () => {
+            process.stdout.write('\n');
+            resolve();
+          },
+          function (event: any) {
+            readline.clearLine(process.stdout, 0);
+            readline.cursorTo(process.stdout, 0);
+            process.stdout.write(
+              `${event.status} ${event.id || ''} ${event.progress || ''}`
+            );
+          }
+        );
+      } else {
+        reject(new Error(`Docker pull failed: ${err}`));
+      }
     });
   });
 }


### PR DESCRIPTION
<!--
1. If there is a breaking or notable change please call that out as these will need to be added to the CHANGELOG.md file in this repository.
-->

## What did you implement:

Properly handles a crash when the docker.pull fails (eg a 404) by showing the error.

<!--
If this closes an open issue please replace xxx below with the issue number
-->

Closes: #13

#### What did you need this functionality for

When using a Rust serverless, it doesn't work & crashes with a mysterious error (Cannot read property 'pipe' of null). However the real issue is that the docker image doesn't exist for rust.

#### How did you verify your change:

npm compile
npm link 
ran in my project, verified that the error message is more clear

#### What (if anything) would need to be called out in the CHANGELOG for the next release:

- Adds better logging for Docker pull failure